### PR TITLE
Disable 'package' doclet

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -64,7 +64,6 @@ function parse(docs, parent)
             case 'mixin':       return handleClass(docs, element, parent);
             case 'module':      return handleNamespace(docs, element, parent);
             case 'namespace':   return handleNamespace(docs, element, parent);
-            case 'package':     return handleNamespace(docs, element, parent);
             case 'typedef':     return handleTypedef(docs, element, parent);
             /* eslint-enable no-multi-spaces */
         }


### PR DESCRIPTION
This is supplied if you pass `-P package.json`, and currently causes `module undefined {}` to show up at the bottom of all generated files. It's not necessary.

(BTW, this project is awesome.)