### PR TITLE
Do not generate private definitions if configured

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -24,6 +24,12 @@ module.exports.publish = function publishTsd(data, opts)
     // remove undocumented stuff.
     data({ undocumented: true }).remove();
 
+    // remove private members if configured.
+    if (opts.private === false)
+    {
+        data({ access: "private" }).remove();
+    }
+
     const docs = data().get();
 
     if (opts.destination === 'console')
@@ -140,7 +146,7 @@ function queueInterfaceForObjectType(element)
 
 function writeInterfaceForObjectType(element)
 {
-    let prefix = env.conf.templates.jsdoc2tsd.interfacePrefix;
+    let prefix = env.conf.templates.jsdoc2tsd && env.conf.templates.jsdoc2tsd.interfacePrefix;
 
     if (!prefix)
         prefix = '';


### PR DESCRIPTION
Also fixes an error thrown when there is nothing configured for the jsdoc2tsd template (in InterfaceForObjectType).

See: https://github.com/englercj/tsd-jsdoc/issues/9