### PR TITLE
Also generate overrides

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -320,18 +320,9 @@ function handleFunction(docs, element, parent, isConstructor)
 {
     const name = isConstructor ? 'constructor' : element.name;
 
-    // skip if parent already defines it
-    if (parent && parent.augments)
-    {
-        for (let i = 0; i < parent.augments.length; ++i)
-        {
-            const aug = parent.augments[i];
-            const children = findChildrenOf(docs, aug);
-
-            if (children.filter((v) => v.name === element.name).length)
-                return;
-        }
-    }
+    // skip if purely inherited
+    if (element.inherited)
+        return;
 
     // comment
     writeComment(element.comment);
@@ -382,18 +373,9 @@ function handleMember(docs, element, parent)
     if (isInterface(element))
         writeInterfaceForObjectType(element);
 
-    // skip if parent already defines it
-    if (parent && parent.augments)
-    {
-        for (let i = 0; i < parent.augments.length; ++i)
-        {
-            const aug = parent.augments[i];
-            const children = findChildrenOf(docs, aug);
-
-            if (children.filter((v) => v.name === element.name).length)
-                return;
-        }
-    }
+    // skip if purely inherited
+    if (element.inherited)
+        return;
 
     // comment
     writeComment(element.comment);


### PR DESCRIPTION
This PR changes the way tsd-jsdoc checks for members already declared on the parent. Instead of searching for an already existing member with the same name on any parent, it now checks if the member is actually inherited, so that explicitly overridden members (i.e. a method that has a different signature) are generated.

This might affect other projects using tsd-jsdoc, depending on how overrides are documented there. If, for example, an `@override` annotation is present, then the member will still be skipped with the PR applied, but if it is not explicitly annotated as one, the member will now be generated. This is a bit counter-intuitive but it seems to be the jsdoc-way (it discards any jsdoc on the child when it sees `@override`, just like `@inheritdoc` does - [see](http://usejsdoc.org/tags-override.html))

See: https://github.com/englercj/tsd-jsdoc/issues/9