### PR TITLE
Add support and tests for @return Promise<T>

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -293,6 +293,7 @@ function getTypeName(obj)
     name = name.replace(/\*|mixed/g, 'any');
     name = name.replace(/(^|[^\w])function(?:\(\))?([^\w]|$)/gi, '$1(() => any)$2');
     name = name.replace(/object/g, 'Object');
+    name = name.replace(/.</g, '<');
 
     return name;
 }

--- a/test/expected/expected.d.ts
+++ b/test/expected/expected.d.ts
@@ -112,6 +112,13 @@ declare class MyThing extends OtherThing implements Stuff, Things {
     */
    D: string;
 
+  /**
+   * Gets a Promise that will resolve with an Object.
+   *
+   * @return {Promise<Object>} The Promise
+   */
+   promiseMe(): Promise<Object>;
+
 }
 
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -122,4 +122,15 @@ class MyThing extends OtherThing
     {
         this.derp = v;
     }
+
+    /**
+     * Gets a Promise that will resolve with an Object.
+     *
+     * @return {Promise<Object>} The Promise
+     */
+    promiseMe() {
+      return new Promise((resolve) => {
+        resolve({});
+      });
+    }
 }


### PR DESCRIPTION
Hello, this small PR allows a function to return a Promise that will resolve to a given Type, e.g. `@return {Promise<Object>}`.

Prior to this PR, use of `@returns {Promise<T>}` mapped to the invalid `Promise.<T>`

Technically this will also add support for AnyContainer\<T\>, but the test case is specific to the use of a Promise as that's the problem I ran into - see https://github.com/lovell/sharp/issues/472#issuecomment-261541473