### PR TITLE
Adds empty array as sentinel value when parameters are undefined

### DIFF
--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -194,7 +194,9 @@ export default class Emitter {
             ) {
                 const d = doclet as IFunctionDoclet;
                 const o = (doclet.kind === 'typedef' ? (obj as any).type : obj) as dom.MethodDeclaration;
-
+                if (o.parameters == undefined) {
+                    o.parameters = new Array();
+                }
                 // resolve parameter types
                 for (let i = 0; i < o.parameters.length; ++i) {
                     (o.parameters[i] as any)._parent = o;


### PR DESCRIPTION
### Problem

When running recursively (`jsdoc -t ./node_modules/tsd-jsdoc ./lib -r`) on a large project with multiple files was encountering:
```
/Users/macleodbroad/workspaces/vis/node_modules/tsd-jsdoc/Emitter.js:148
                for (let i = 0; i < o.parameters.length; ++i) {
                                                ^

TypeError: Cannot read property 'length' of undefined
    at Emitter._resolveObjects (/Users/macleodbroad/workspaces/vis/node_modules/tsd-jsdoc/Emitter.js:148:49)
    at Emitter.parse (/Users/macleodbroad/workspaces/vis/node_modules/tsd-jsdoc/Emitter.js:57:14)
    at new Emitter (/Users/macleodbroad/workspaces/vis/node_modules/tsd-jsdoc/Emitter.js:49:14)
    at Object.publish (/Users/macleodbroad/workspaces/vis/node_modules/tsd-jsdoc/publish.js:10:21)
    at Object.module.exports.cli.generateDocs (/usr/local/lib/node_modules/jsdoc/cli.js:448:35)
    at Object.module.exports.cli.processParseResults (/usr/local/lib/node_modules/jsdoc/cli.js:399:20)
    at module.exports.cli.main (/usr/local/lib/node_modules/jsdoc/cli.js:240:14)
    at Object.module.exports.cli.runCommand (/usr/local/lib/node_modules/jsdoc/cli.js:189:5)
    at /usr/local/lib/node_modules/jsdoc/jsdoc.js:105:9
    at Object.<anonymous> (/usr/local/lib/node_modules/jsdoc/jsdoc.js:106:3)
    at Module._compile (module.js:573:30)
    at Object.Module._extensions..js (module.js:584:10)
    at Module.load (module.js:507:32)
    at tryModuleLoad (module.js:470:12)
    at Function.Module._load (module.js:462:3)
    at Function.Module.runMain (module.js:609:10)
```
### Solution

Assign a sentinel value of an empty array to `o.parameters` when `o.parameters` is undefined.

### Other Observations

Running against the file alone did not invoke the same exception:
```
jsdoc -t ./node_modules/tsd-jsdoc ./lib/timeline/Range.js
```