### PR TITLE
fix 'No such file or directory' error when creating definition for private-scoped packages

### DIFF
--- a/src/publish.ts
+++ b/src/publish.ts
@@ -43,7 +43,11 @@ export function publish(data: TDocletDb, opts: ITemplateConfig)
 
         const pkgArray: any = helper.find(data, { kind: 'package' }) || [];
         const pkg = pkgArray[0] as IPackageDoclet;
-        const out = path.join(opts.destination, opts.outFile || (pkg && pkg.name ? `${pkg.name}.d.ts` : 'types.d.ts'));
+        let definitionName: string = 'types';
+        if (pkg && pkg.name) {
+          definitionName = pkg.name.split('/').pop() || definitionName;
+        }
+        const out = path.join(opts.destination, opts.outFile || `${definitionName}.d.ts`);
 
         fs.writeFileSync(out, emitter.emit());
     }


### PR DESCRIPTION
Hi,

I ran into an issue running this JSDoc template on one of my packages where the TS definition couldn't be created. The `src/publish.ts` file creates the TS definition and gives it a name that matches the `name` prop from a given package's `package.json` file and places it in the `docs/` directory. Normally that works fine, however for private-scoped packages this doesn't work because `fs.writeFileSync()` won't create the full nested file path.

There's probably a couple of options to solve that:
  * Use a combination of `fs.existsSync('docs/@my-scope')` followed by `fs.mkdirSync('docs/@myscope')` prior to writing `docs/@my-scope/package-name.d.ts`
  * Get rid of the leading `@my-scope/` prefix from the pacakge's name when writing `docs/package-name.d.ts`

That last option seems sensible to me, but I'm not sure if I'm missing an edge-case where there is an important reason to keep the private scope as a folder inside of `docs/`. Let me know if you want to go with a different option instead, or if you have any other feedback on this particular implementation.

Thanks!