### PR TITLE
Fix/files and callbacks

### DIFF
--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -251,6 +251,7 @@ export class Emitter
                 else
                     return createNamespaceMember(node.doclet);
 
+            case 'callback':
             case 'function':
                 if (node.doclet.memberof)
                 {
@@ -277,6 +278,9 @@ export class Emitter
 
             case 'typedef':
                 return createTypedef(node.doclet, children);
+
+            case 'file':
+                return null;
 
             case 'event':
                 // TODO: Handle Events.

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -43,7 +43,11 @@ export function publish(data: TDocletDb, opts: ITemplateConfig)
 
         const pkgArray: any = helper.find(data, { kind: 'package' }) || [];
         const pkg = pkgArray[0] as IPackageDoclet;
-        const out = path.join(opts.destination, opts.outFile || (pkg && pkg.name ? `${pkg.name}.d.ts` : 'types.d.ts'));
+        let definitionName: string = 'types';
+        if (pkg && pkg.name) {
+          definitionName = pkg.name.split('/').pop() || definitionName;
+        }
+        const out = path.join(opts.destination, opts.outFile || `${definitionName}.d.ts`);
 
         fs.writeFileSync(out, emitter.emit());
     }

--- a/src/typings/jsdoc.d.ts
+++ b/src/typings/jsdoc.d.ts
@@ -102,13 +102,18 @@ declare interface IClassDoclet extends IDocletBase {
     classdesc?: string;
 }
 
+declare interface IFileDoclet extends IDocletBase {
+    kind: 'file';
+    params?: IDocletProp[];
+}
+
 declare interface IEventDoclet extends IDocletBase {
     kind: 'event';
     params?: IDocletProp[];
 }
 
 declare interface IFunctionDoclet extends IDocletBase {
-    kind: 'function';
+    kind: 'function' | 'callback';
     this?: string;
     params?: IDocletProp[];
     returns?: IDocletReturn[];
@@ -147,6 +152,7 @@ declare interface IPackageDoclet {
 declare type TDoclet = (
     IClassDoclet
     | IEventDoclet
+    | IFileDoclet
     | IFunctionDoclet
     | IMemberDoclet
     | INamespaceDoclet


### PR DESCRIPTION
Just adds an additional ignore for doclets of the kind "file". Not needed in a TS definition file, so they should be able to be safely ignored if found.

Also added in a case for doclets of the kind "callback", essentially to treat them the same as functions.