### PR TITLE
resolve complex types and workaround promise reject types

### DIFF
--- a/test/expected/class_all.d.ts
+++ b/test/expected/class_all.d.ts
@@ -158,11 +158,23 @@ declare module "util" {
          */
         static create(opts: FoobarNS.CircleOptions): MyThing;
         /**
-         * Gets a Promise that will resolve with an Object.
+         * Gets a Promise that will resolve with an Object, or reject with OtherThing
          *
-         * @return {Promise<Object>} The Promise
+         * @return {Promise<Object, OtherThing>} The Promise
          */
-        promiseMe(): Promise<any>;
+        promiseMe(): Promise<object>;
+        /**
+         * Gets a Promise that will resolve with an array of OtherThings
+         *
+         * @return {Promise<Array.<OtherThing>>} The Promise
+         */
+        promiseYou(): Promise<OtherThing[]>;
+        /**
+         * Gets a Promise that will resolve with a bunch of possible types
+         *
+         * @return {Promise<Array.<*>|Object|number|string>} The Promise
+         */
+        promiseFoo(): Promise<any[] | object | number | string>;
         /**
          *
          * @param {GitGraphOptions} options - GitGraph options

--- a/test/fixtures/class_all.js
+++ b/test/fixtures/class_all.js
@@ -165,11 +165,27 @@ class MyThing extends OtherThing {
     }
 
     /**
-     * Gets a Promise that will resolve with an Object.
+     * Gets a Promise that will resolve with an Object, or reject with OtherThing
      *
-     * @return {Promise<Object>} The Promise
+     * @return {Promise<Object, OtherThing>} The Promise
      */
     promiseMe() {
+    }
+
+    /**
+     * Gets a Promise that will resolve with an array of OtherThings
+     *
+     * @return {Promise<Array.<OtherThing>>} The Promise
+     */
+    promiseYou() {
+    }
+
+    /**
+     * Gets a Promise that will resolve with a bunch of possible types
+     *
+     * @return {Promise<Array.<*>|Object|number|string>} The Promise
+     */
+    promiseFoo() {
     }
 
     /**


### PR DESCRIPTION
2 things here, let me know and I can split them.

1) Complex types like a union that had a generic, or a generic that had a union could not be resolved, ex: Promise<Array.<*>|Object|number|string>

2) We like to document our promise resolve and rejection types separated with a comma, ex: Promise<ResolveType, RejectType>.  There doesn't seem to be consensus on exactly how do to this based on this still open feature request: https://github.com/jsdoc3/jsdoc/issues/509.  Typescript does not define the RejectType of a promise it is always 'any', see: https://github.com/Microsoft/TypeScript/issues/7588.  Due to this I've added a workaround that removes the second type when parsing a Promise.

Thanks btw,
- Gord