### PR TITLE
Support objects in complex types, Fixes: #65

### DIFF
--- a/test/expected/class_all.d.ts
+++ b/test/expected/class_all.d.ts
@@ -176,6 +176,12 @@ declare module "util" {
          */
         promiseFoo(): Promise<any[] | object | number | string>;
         /**
+         * Gets a Promise that will resolve with an object with complex properties
+         *
+         * @return {Promise<{newChannels: Channel[], foo: Bar}>} The Promise
+         */
+        promiseBar(): Promise<{ newChannels: Channel[]; foo: Bar; }>;
+        /**
          *
          * @param {GitGraphOptions} options - GitGraph options
          */

--- a/test/fixtures/class_all.js
+++ b/test/fixtures/class_all.js
@@ -189,6 +189,14 @@ class MyThing extends OtherThing {
     }
 
     /**
+     * Gets a Promise that will resolve with an object with complex properties
+     *
+     * @return {Promise<{newChannels: Channel[], foo: Bar}>} The Promise
+     */
+    promiseBar() {
+    }
+
+    /**
      *
      * @param {GitGraphOptions} options - GitGraph options
      */


### PR DESCRIPTION
Adds object handling to resolveComplexTypeName, Fixes: #65

Note: for #65 there must be a space after the colon in the object definition or jsdoc doesn't parse it correctly.

```
// Bad:
newChannels:Channel[]
// Good:
newChannels: Channel[]
```