### PR TITLE
Add function support to complex types

### DIFF
--- a/test/expected/class_all.d.ts
+++ b/test/expected/class_all.d.ts
@@ -182,6 +182,45 @@ declare module "util" {
          */
         promiseBar(): Promise<{ newChannels: Channel[]; foo: Bar; }>;
         /**
+         * Gets a Promise that will resolve with a generic function
+         *
+         * @return {Promise<Function>} The Promise
+         */
+        promiseGenericFunc(): Promise<(...params: any[]) => void>;
+        /**
+         * Gets a Promise that will resolve with a function with no arguments
+         * that returns a string.
+         *
+         * @return {Promise<Function(): string>} The Promise
+         */
+        promiseStringFunc(): Promise<(...params: any[]) => string>;
+        /**
+         * Gets a Promise that will resolve with a function with lots of arguments
+         * that returns an object.
+         *
+         * @return {Promise<Function(Array.<OtherThing>, object, number, string): object>} The Promise
+         */
+        promiseLotsArgsFunc(): Promise<(arg0: OtherThing[], arg1: object, arg2: number, arg3: string) => object>;
+        /**
+         * Gets a Promise that will resolve with a function with lots of arguments
+         * that returns the default type.
+         *
+         * @return {Promise<Function(Array.<OtherThing>, object, number, string)>} The Promise
+         */
+        promiseDefaultRetFunc(): Promise<(arg0: OtherThing[], arg1: object, arg2: number, arg3: string) => void>;
+        /**
+         * A param that is a function
+         * Note: doesn't matter what I put, a @param only gets "FUNCTION" from jsdoc
+         * @param {function(number): object}
+         */
+        takeFuncParam(f: (...params: any[]) => any): void;
+        /**
+         * A param that is a complex function
+         * Note: doesn't matter what I put, a @param only gets "FUNCTION" from jsdoc
+         * @param {function(Array.<OtherThing>, object, number): object}
+         */
+        takeFuncParamComplex(f: (...params: any[]) => any): void;
+        /**
          *
          * @param {GitGraphOptions} options - GitGraph options
          */

--- a/test/expected/typedef_all.d.ts
+++ b/test/expected/typedef_all.d.ts
@@ -100,6 +100,11 @@ declare type NumberLike = number | string;
  *    `color: "url(#pattern-id)"`.
  * @property {Object|Boolean} animation Animation options for the image pattern
  *  loading.
+ * Note: doesn't matter what I put, a @property only gets "FUNCTION" from jsdoc
+ * @property {function(number): void} rotate Rotates the pattern by degrees
+ * @property {function} wiggle Wiggles the pattern (default function)
+ * @property {function(string, number): Promise<number>} wobble Wobbles the pattern
+ *  (complex function)
  */
 declare type PatternOptions = {
     pattern: {
@@ -115,6 +120,9 @@ declare type PatternOptions = {
         id: string;
     };
     animation: any | boolean;
+    rotate: (...params: any[]) => any;
+    wiggle: (...params: any[]) => any;
+    wobble: (...params: any[]) => any;
 };
 
 

--- a/test/fixtures/class_all.js
+++ b/test/fixtures/class_all.js
@@ -197,6 +197,57 @@ class MyThing extends OtherThing {
     }
 
     /**
+     * Gets a Promise that will resolve with a generic function
+     *
+     * @return {Promise<Function>} The Promise
+     */
+    promiseGenericFunc() {
+    }
+
+    /**
+     * Gets a Promise that will resolve with a function with no arguments
+     * that returns a string.
+     *
+     * @return {Promise<Function(): string>} The Promise
+     */
+    promiseStringFunc() {
+    }
+
+    /**
+     * Gets a Promise that will resolve with a function with lots of arguments
+     * that returns an object.
+     *
+     * @return {Promise<Function(Array.<OtherThing>, object, number, string): object>} The Promise
+     */
+    promiseLotsArgsFunc() {
+    }
+
+    /**
+     * Gets a Promise that will resolve with a function with lots of arguments
+     * that returns the default type.
+     *
+     * @return {Promise<Function(Array.<OtherThing>, object, number, string)>} The Promise
+     */
+    promiseDefaultRetFunc() {
+    }
+
+    /**
+     * A param that is a function
+     * Note: doesn't matter what I put, a @param only gets "FUNCTION" from jsdoc
+     * @param {function(number): object}
+     */
+    takeFuncParam(f) {
+    }
+
+    /**
+     * A param that is a complex function
+     * Note: doesn't matter what I put, a @param only gets "FUNCTION" from jsdoc
+     * @param {function(Array.<OtherThing>, object, number): object}
+     */
+    takeFuncParamComplex(f) {
+    }
+
+    /**
      *
      * @param {GitGraphOptions} options - GitGraph options
      */

--- a/test/fixtures/typedef_all.js
+++ b/test/fixtures/typedef_all.js
@@ -69,4 +69,9 @@
  *    `color: "url(#pattern-id)"`.
  * @property {Object|Boolean} animation Animation options for the image pattern
  *  loading.
+ * Note: doesn't matter what I put, a @property only gets "FUNCTION" from jsdoc
+ * @property {function(number): void} rotate Rotates the pattern by degrees
+ * @property {function} wiggle Wiggles the pattern (default function)
+ * @property {function(string, number): Promise<number>} wobble Wobbles the pattern
+ *  (complex function)
  */


### PR DESCRIPTION
Adds function support to complex type lookups.  Not sure how you feel about the auto-generated "arg0" names, ex:

promiseLotsArgsFunc(): Promise<(arg0: OtherThing[], arg1: object, arg2: number, arg3: etc

But I copied the typescript in their handling of this.  Also I think it will be a rare case where you would return a function that takes multiple arguments.

Let me know what you think.