### PR TITLE
support for simple Array type

### DIFF
--- a/src/type_resolve_helpers.ts
+++ b/src/type_resolve_helpers.ts
@@ -193,6 +193,8 @@ function generateTree(name: string, parent: StringTreeNode | null = null) : Stri
             node.name = 'any';
         else if (partUpper === 'OBJECT')
             node.name = 'object';
+        else if (partUpper === 'ARRAY')
+            node.name = '[]';
 
         if (!parent)
             return node;

--- a/src/type_resolve_helpers.ts
+++ b/src/type_resolve_helpers.ts
@@ -194,7 +194,7 @@ function generateTree(name: string, parent: StringTreeNode | null = null) : Stri
         else if (partUpper === 'OBJECT')
             node.name = 'object';
         else if (partUpper === 'ARRAY')
-            node.name = '[]';
+            node.name = 'any[]';
 
         if (!parent)
             return node;

--- a/test/expected/class_all.d.ts
+++ b/test/expected/class_all.d.ts
@@ -153,7 +153,7 @@ declare module "util" {
         /**
          * @member {Array}
          */
-        simpleArray: [];
+        simpleArray: any[];
         /**
          * Creates a new thing.
          *

--- a/test/expected/class_all.d.ts
+++ b/test/expected/class_all.d.ts
@@ -151,6 +151,10 @@ declare module "util" {
          */
         superArray: string[][][][][];
         /**
+         * @member {Array}
+         */
+        simpleArray: [];
+        /**
          * Creates a new thing.
          *
          * @param {!FoobarNS.CircleOptions} opts - Namespace test!

--- a/test/expected/function_all.d.ts
+++ b/test/expected/function_all.d.ts
@@ -11,6 +11,14 @@ declare function test1(a?: number, input: {
 }): void;
 
 /**
+ *
+ * @param {Array<*>} x
+ * @param {Array.<*>} y
+ * @param {Array} z
+ */
+declare function test2(x: any[], y: any[], z: []): void;
+
+/**
  * @class
  */
 declare class Test12345 {

--- a/test/expected/function_all.d.ts
+++ b/test/expected/function_all.d.ts
@@ -17,7 +17,7 @@ declare function test1(a?: number, input: {
  * @param {Array} z
  * @param {Array<Array>} w
  */
-declare function test2(x: any[], y: any[], z: [], w: [][]): void;
+declare function test2(x: any[], y: any[], z: any[], w: any[][]): void;
 
 /**
  * @class

--- a/test/expected/function_all.d.ts
+++ b/test/expected/function_all.d.ts
@@ -15,8 +15,9 @@ declare function test1(a?: number, input: {
  * @param {Array<*>} x
  * @param {Array.<*>} y
  * @param {Array} z
+ * @param {Array<Array>} w
  */
-declare function test2(x: any[], y: any[], z: []): void;
+declare function test2(x: any[], y: any[], z: [], w: [][]): void;
 
 /**
  * @class

--- a/test/fixtures/class_all.js
+++ b/test/fixtures/class_all.js
@@ -144,6 +144,11 @@ class MyThing extends OtherThing {
          * @member {Array<Array.<Array<Array.<string[]>>>>}
          */
         this.superArray = {};
+
+        /**
+         * @member {Array}
+         */
+        this.simpleArray = [];
     }
 
     /**

--- a/test/fixtures/function_all.js
+++ b/test/fixtures/function_all.js
@@ -9,6 +9,15 @@ function test1(input) {
 }
 
 /**
+ *
+ * @param {Array<*>} x
+ * @param {Array.<*>} y
+ * @param {Array} z
+ */
+function test2(x, y, z, w) {
+}
+
+/**
  * @class
  */
 class Test12345 {

--- a/test/fixtures/function_all.js
+++ b/test/fixtures/function_all.js
@@ -13,6 +13,7 @@ function test1(input) {
  * @param {Array<*>} x
  * @param {Array.<*>} y
  * @param {Array} z
+ * @param {Array<Array>} w
  */
 function test2(x, y, z, w) {
 }


### PR DESCRIPTION
Fixes support for jsdoc's standalone `Array` keyword as can be seen in examples such as:
```javascript
/**
 * Returns the sum of a and b
 * @param {number} a
 * @param {number} b
 * @param {boolean} retArr If set to true, the function will return an array
 * @returns {(number|Array)} Sum of a and b or an array that contains a, b and the sum of a and b.
 */
function sum(a, b, retArr) {
    if (retArr) {
        return [a, b, a + b];
    }
    return a + b;
}
```
Source: https://jsdoc.app/tags-returns.html

Without this PR, `tsd-jsdoc` will generate invalid typescript (because outputting just `Array` will conflict with the built-in generic interface `Array<T>` ).