### PR TITLE
support optional methods and members

### DIFF
--- a/src/create_helpers.ts
+++ b/src/create_helpers.ts
@@ -204,12 +204,6 @@ export function createInterfaceMethod(doclet: IFunctionDoclet): ts.MethodSignatu
     const type = createFunctionReturnType(doclet);
     const typeParams = resolveTypeParameters(doclet);
 
-    if (!doclet.memberof)
-        mods.push(declareModifier);
-
-    if (doclet.scope === 'static')
-        mods.push(ts.createModifier(ts.SyntaxKind.StaticKeyword));
-
     if (doclet.name.startsWith('exports.'))
         doclet.name = doclet.name.replace('exports.', '');
 

--- a/src/create_helpers.ts
+++ b/src/create_helpers.ts
@@ -1,6 +1,6 @@
 import * as ts from 'typescript';
 import { warn } from './logger';
-import { resolveType, createFunctionParams, createFunctionReturnType, resolveTypeParameters, resolveHeritageClauses } from './type_resolve_helpers';
+import { resolveType, createFunctionParams, createFunctionReturnType, resolveTypeParameters, resolveHeritageClauses, resolveOptionalFromName } from './type_resolve_helpers';
 
 const declareModifier = ts.createModifier(ts.SyntaxKind.DeclareKeyword);
 const constModifier = ts.createModifier(ts.SyntaxKind.ConstKeyword);
@@ -184,12 +184,13 @@ export function createClassMethod(doclet: IFunctionDoclet): ts.MethodDeclaration
     if (doclet.name.startsWith('exports.'))
         doclet.name = doclet.name.replace('exports.', '');
 
+    var [ name, questionToken ] = resolveOptionalFromName(doclet);
     return handleComment(doclet, ts.createMethod(
         undefined,      // decorators
         mods,           // modifiers
         undefined,      // asteriskToken
-        doclet.name,    // name
-        undefined,      // questionToken
+        name,           // name
+        questionToken,  // questionToken
         typeParams,     // typeParameters
         params,         // parameters
         type,           // type
@@ -207,12 +208,13 @@ export function createInterfaceMethod(doclet: IFunctionDoclet): ts.MethodSignatu
     if (doclet.name.startsWith('exports.'))
         doclet.name = doclet.name.replace('exports.', '');
 
+    var [ name, questionToken ] = resolveOptionalFromName(doclet);
     return handleComment(doclet, ts.createMethodSignature(
         typeParams,     // typeParameters
         params,         // parameters
         type,           // type
-        doclet.name,    // name
-        undefined       // questionToken
+        name,           // name
+        questionToken,  // questionToken
     ));
 }
 
@@ -264,11 +266,12 @@ export function createClassMember(doclet: IMemberDoclet): ts.PropertyDeclaration
     if (doclet.kind === 'constant' || doclet.readonly)
         mods.push(readonlyModifier);
 
+    var [ name, questionToken ] = resolveOptionalFromName(doclet);
     return handleComment(doclet, ts.createProperty(
         undefined,      // decorators
         mods,           // modifiers
-        doclet.name,    // name
-        undefined,      // questionToken
+        name,           // name
+        questionToken,  // questionToken
         type,           // type
         undefined       // initializer
     ));
@@ -285,10 +288,11 @@ export function createInterfaceMember(doclet: IMemberDoclet): ts.PropertySignatu
     if (doclet.scope === 'static')
         mods.push(ts.createModifier(ts.SyntaxKind.StaticKeyword));
 
+    var [ name, questionToken ] = resolveOptionalFromName(doclet);
     return handleComment(doclet, ts.createPropertySignature(
         mods,           // modifiers
-        doclet.name,    // name
-        undefined,      // questionToken
+        name,           // name
+        questionToken,  // questionToken
         type,           // type
         undefined       // initializer
     ));

--- a/src/create_helpers.ts
+++ b/src/create_helpers.ts
@@ -222,7 +222,7 @@ export function createClassMethod(doclet: IFunctionDoclet): ts.MethodDeclaration
     if (doclet.name.startsWith('exports.'))
         doclet.name = doclet.name.replace('exports.', '');
 
-    var [ name, questionToken ] = resolveOptionalFromName(doclet);
+    const [ name, questionToken ] = resolveOptionalFromName(doclet);
     return handleComment(doclet, ts.createMethod(
         undefined,      // decorators
         mods,           // modifiers
@@ -246,7 +246,7 @@ export function createInterfaceMethod(doclet: IFunctionDoclet): ts.MethodSignatu
     if (doclet.name.startsWith('exports.'))
         doclet.name = doclet.name.replace('exports.', '');
 
-    var [ name, questionToken ] = resolveOptionalFromName(doclet);
+    const [ name, questionToken ] = resolveOptionalFromName(doclet);
     return handleComment(doclet, ts.createMethodSignature(
         typeParams,     // typeParameters
         params,         // parameters
@@ -304,7 +304,7 @@ export function createClassMember(doclet: IMemberDoclet): ts.PropertyDeclaration
     if (doclet.kind === 'constant' || doclet.readonly)
         mods.push(readonlyModifier);
 
-    var [ name, questionToken ] = resolveOptionalFromName(doclet);
+    const [ name, questionToken ] = resolveOptionalFromName(doclet);
     return handleComment(doclet, ts.createProperty(
         undefined,      // decorators
         mods,           // modifiers
@@ -326,7 +326,7 @@ export function createInterfaceMember(doclet: IMemberDoclet): ts.PropertySignatu
     if (doclet.scope === 'static')
         mods.push(ts.createModifier(ts.SyntaxKind.StaticKeyword));
 
-    var [ name, questionToken ] = resolveOptionalFromName(doclet);
+    const [ name, questionToken ] = resolveOptionalFromName(doclet);
     return handleComment(doclet, ts.createPropertySignature(
         mods,           // modifiers
         name,           // name

--- a/src/type_resolve_helpers.ts
+++ b/src/type_resolve_helpers.ts
@@ -479,6 +479,19 @@ export function resolveOptional(doclet: IDocletProp): ts.Token<ts.SyntaxKind.Que
     return undefined;
 }
 
+export function resolveOptionalFromName(doclet: IDocletBase): [ string, ts.Token<ts.SyntaxKind.QuestionToken> | undefined ]
+{
+    let questionToken = undefined;
+    let name = doclet.name;
+
+    if (name.startsWith('[') && name.endsWith(']')) {
+        name = name.substring(1, name.length - 1);
+        questionToken = ts.createToken(ts.SyntaxKind.QuestionToken);
+    }
+
+    return [ name, questionToken ];
+}
+
 export function resolveVariable(doclet: IDocletProp): ts.Token<ts.SyntaxKind.DotDotDotToken> | undefined
 {
     if (doclet.variable)

--- a/src/type_resolve_helpers.ts
+++ b/src/type_resolve_helpers.ts
@@ -473,7 +473,7 @@ export function toKeywordTypeKind(k: string): ts.KeywordTypeNode['kind'] | null
     }
 }
 
-export function resolveOptional(doclet: IDocletProp): ts.Token<ts.SyntaxKind.QuestionToken> | undefined
+export function resolveOptionalParameter(doclet: IDocletProp): ts.Token<ts.SyntaxKind.QuestionToken> | undefined
 {
     if (doclet.defaultvalue || doclet.optional)
         return ts.createToken(ts.SyntaxKind.QuestionToken);
@@ -481,25 +481,28 @@ export function resolveOptional(doclet: IDocletProp): ts.Token<ts.SyntaxKind.Que
     return undefined;
 }
 
-export function resolveOptionalFromName(doclet: IDocletBase): [ string, ts.Token<ts.SyntaxKind.QuestionToken> | undefined ]
-{
-    let questionToken = undefined;
-    let name = doclet.name;
-
-    if (name.startsWith('[') && name.endsWith(']')) {
-        name = name.substring(1, name.length - 1);
-        questionToken = ts.createToken(ts.SyntaxKind.QuestionToken);
-    }
-
-    return [ name, questionToken ];
-}
-
-export function resolveVariable(doclet: IDocletProp): ts.Token<ts.SyntaxKind.DotDotDotToken> | undefined
+export function resolveVariableParameter(doclet: IDocletProp): ts.Token<ts.SyntaxKind.DotDotDotToken> | undefined
 {
     if (doclet.variable)
         return ts.createToken(ts.SyntaxKind.DotDotDotToken);
 
     return undefined;
+}
+
+export function resolveOptionalFromName(doclet: IDocletBase): [ string, ts.Token<ts.SyntaxKind.QuestionToken> | undefined ]
+{
+    let name = doclet.name;
+
+    if (name.startsWith('[') && name.endsWith(']')) {
+        name = name.substring(1, name.length - 1);
+        return [ name, ts.createToken(ts.SyntaxKind.QuestionToken) ];
+    }
+
+    if (doclet.optional) {
+        return [ name, ts.createToken(ts.SyntaxKind.QuestionToken) ];
+    }
+
+    return [ name, undefined ];
 }
 
 function getExprWithTypeArgs(identifier: string)
@@ -742,8 +745,8 @@ export function createFunctionParams(doclet: IFunctionDoclet | ITypedefDoclet | 
     for (let i = 0; i < tree.roots.length; ++i)
     {
         const node = tree.roots[i];
-        const opt = resolveOptional(node.prop);
-        const dots = resolveVariable(node.prop);
+        const opt = resolveOptionalParameter(node.prop);
+        const dots = resolveVariableParameter(node.prop);
         let type = node.children.length ? createTypeLiteral(node.children) : resolveType(node.prop.type);
 
         if (dots)

--- a/src/typings/jsdoc.d.ts
+++ b/src/typings/jsdoc.d.ts
@@ -87,6 +87,7 @@ declare interface IDocletBase {
     properties?: IDocletProp[];
     inherits?: string;
     inherited?: boolean;
+    optional?: boolean;
 }
 
 /**

--- a/test/expected/class_all.d.ts
+++ b/test/expected/class_all.d.ts
@@ -33,12 +33,11 @@ declare class Things {
      */
     doThings(): void;
     /**
-     * @function
-     * @name Things#[foobar1]
+     * @method Things#[foobar1]
      */
     foobar1?(): void;
     /**
-     * @member {Number}
+     * @type {Number}
      * @name Things#[foobar2]
      */
     foobar2?: number;

--- a/test/expected/class_all.d.ts
+++ b/test/expected/class_all.d.ts
@@ -32,6 +32,15 @@ declare class Things {
      *
      */
     doThings(): void;
+    /**
+     * @function Things#[foobar1]
+     */
+    foobar1?(): void;
+    /**
+     * @name Things#[foobar2]
+     * @type {Number}
+     */
+    foobar2?: number;
 }
 
 /**

--- a/test/expected/class_all.d.ts
+++ b/test/expected/class_all.d.ts
@@ -33,12 +33,13 @@ declare class Things {
      */
     doThings(): void;
     /**
-     * @function Things#[foobar1]
+     * @function
+     * @name Things#[foobar1]
      */
     foobar1?(): void;
     /**
+     * @member {Number}
      * @name Things#[foobar2]
-     * @type {Number}
      */
     foobar2?: number;
 }

--- a/test/expected/interface_all.d.ts
+++ b/test/expected/interface_all.d.ts
@@ -13,12 +13,22 @@ declare interface Color {
      */
     rgb(): number[];
     /**
-     * @function Color#[foobar1]
+     * @function
+     * @name Color#[foobar1]
      */
     foobar1?(): void;
     /**
-     * @name Color#[foobar2]
-     * @type {Number}
+     * @function Color#[foobar2]
      */
-    foobar2?: number;
+    foobar2?(): void;
+    /**
+     * @type {Boolean}
+     * @name Color#[foobar3]
+     */
+    foobar3?: boolean;
+    /**
+     * @member {String}
+     * @name Color#[foobar4]
+     */
+    foobar4?: string;
 }

--- a/test/expected/interface_all.d.ts
+++ b/test/expected/interface_all.d.ts
@@ -14,21 +14,30 @@ declare interface Color {
     rgb(): number[];
     /**
      * @function
-     * @name Color#[foobar1]
+     * @name [foobar1]
+     * @memberof Color#
      */
     foobar1?(): void;
     /**
-     * @function Color#[foobar2]
+     * @function [foobar2]
+     * @memberof Color#
      */
     foobar2?(): void;
     /**
      * @type {Boolean}
-     * @name Color#[foobar3]
+     * @name [foobar3]
+     * @memberof Color#
      */
     foobar3?: boolean;
     /**
      * @member {String}
-     * @name Color#[foobar4]
+     * @name [foobar4]
+     * @memberof Color#
      */
     foobar4?: string;
+    /**
+     * @member {Object} [foobar5]
+     * @memberof Color#
+     */
+    foobar5?: any;
 }

--- a/test/expected/interface_all.d.ts
+++ b/test/expected/interface_all.d.ts
@@ -12,6 +12,13 @@ declare interface Color {
      * in that order.
      */
     rgb(): number[];
+    /**
+     * @function Color#[foobar1]
+     */
+    foobar1?(): void;
+    /**
+     * @name Color#[foobar2]
+     * @type {Number}
+     */
+    foobar2?: number;
 }
-
-

--- a/test/fixtures/class_all.js
+++ b/test/fixtures/class_all.js
@@ -36,6 +36,18 @@ class Things {
      */
     doThings() {
     }
+
+    /**
+     * @function Things#[foobar1]
+     */
+    foobar1() {
+    };
+
+    /**
+     * @name Things#[foobar2]
+     * @type {Number}
+     */
+    foobar2 = undefined;
 }
 
 /**

--- a/test/fixtures/class_all.js
+++ b/test/fixtures/class_all.js
@@ -38,14 +38,13 @@ class Things {
     }
 
     /**
-     * @function
-     * @name Things#[foobar1]
+     * @method Things#[foobar1]
      */
     foobar1() {
     };
 
     /**
-     * @member {Number}
+     * @type {Number}
      * @name Things#[foobar2]
      */
     foobar2 = undefined;

--- a/test/fixtures/class_all.js
+++ b/test/fixtures/class_all.js
@@ -38,14 +38,15 @@ class Things {
     }
 
     /**
-     * @function Things#[foobar1]
+     * @function
+     * @name Things#[foobar1]
      */
     foobar1() {
     };
 
     /**
+     * @member {Number}
      * @name Things#[foobar2]
-     * @type {Number}
      */
     foobar2 = undefined;
 }

--- a/test/fixtures/interface_all.js
+++ b/test/fixtures/interface_all.js
@@ -16,4 +16,15 @@ Color.prototype.rgb = function() {
     throw new Error('not implemented');
 };
 
+/**
+ * @function Color#[foobar1]
+ */
+Color.prototype.foobar1 = function() {
+    throw new Error('not implemented');
+};
 
+/**
+ * @name Color#[foobar2]
+ * @type {Number}
+ */
+Color.prototype.foobar2 = undefined;

--- a/test/fixtures/interface_all.js
+++ b/test/fixtures/interface_all.js
@@ -17,14 +17,28 @@ Color.prototype.rgb = function() {
 };
 
 /**
- * @function Color#[foobar1]
+ * @function
+ * @name Color#[foobar1]
  */
 Color.prototype.foobar1 = function() {
     throw new Error('not implemented');
 };
 
 /**
- * @name Color#[foobar2]
- * @type {Number}
+ * @function Color#[foobar2]
  */
-Color.prototype.foobar2 = undefined;
+Color.prototype.foobar2 = function() {
+    throw new Error('not implemented');
+};
+
+/**
+ * @type {Boolean}
+ * @name Color#[foobar3]
+ */
+Color.prototype.foobar3 = undefined;
+
+/**
+ * @member {String}
+ * @name Color#[foobar4]
+ */
+Color.prototype.foobar4 = undefined;

--- a/test/fixtures/interface_all.js
+++ b/test/fixtures/interface_all.js
@@ -18,14 +18,16 @@ Color.prototype.rgb = function() {
 
 /**
  * @function
- * @name Color#[foobar1]
+ * @name [foobar1]
+ * @memberof Color#
  */
 Color.prototype.foobar1 = function() {
     throw new Error('not implemented');
 };
 
 /**
- * @function Color#[foobar2]
+ * @function [foobar2]
+ * @memberof Color#
  */
 Color.prototype.foobar2 = function() {
     throw new Error('not implemented');
@@ -33,12 +35,20 @@ Color.prototype.foobar2 = function() {
 
 /**
  * @type {Boolean}
- * @name Color#[foobar3]
+ * @name [foobar3]
+ * @memberof Color#
  */
 Color.prototype.foobar3 = undefined;
 
 /**
  * @member {String}
- * @name Color#[foobar4]
+ * @name [foobar4]
+ * @memberof Color#
  */
 Color.prototype.foobar4 = undefined;
+
+/**
+ * @member {Object} [foobar5]
+ * @memberof Color#
+ */
+Color.prototype.foobar5 = undefined;


### PR DESCRIPTION
Currently, there is no way to declare an optional method or member in a class or interface (which is quite useful in TypeScript). This PR adds support for it by allowing the method or member name to be wrapped in brackets (`[myMethod]` or `[myMember]`) to indicate it is optional - just like with parameters.