### PR TITLE
support @constant in a namespace

### DIFF
--- a/src/create_helpers.ts
+++ b/src/create_helpers.ts
@@ -340,8 +340,10 @@ export function createInterfaceMember(doclet: IMemberDoclet): ts.PropertySignatu
 export function createNamespaceMember(doclet: IMemberDoclet): ts.VariableStatement
 {
     const mods = doclet.memberof ? undefined : [declareModifier];
-    const flags = doclet.kind === 'constant' ? ts.NodeFlags.Const : undefined;
-    const type = resolveType(doclet.type, doclet);
+    const flags = (doclet.kind === 'constant' || doclet.readonly) ? ts.NodeFlags.Const : undefined;
+    const literal = doclet.meta && doclet.meta.code.type === 'Literal' ? doclet.meta.code.value : undefined;
+    const initializer = (flags === ts.NodeFlags.Const && literal !== undefined) ? ts.createLiteral(literal) : undefined;
+    const type = initializer ? undefined : resolveType(doclet.type, doclet);
 
     if (doclet.name.startsWith('exports.'))
         doclet.name = doclet.name.replace('exports.', '');
@@ -352,7 +354,7 @@ export function createNamespaceMember(doclet: IMemberDoclet): ts.VariableStateme
             ts.createVariableDeclaration(
                 doclet.name,    // name
                 type,           // type
-                undefined       // initializer
+                initializer     // initializer
                 )
             ],
             flags,

--- a/src/create_helpers.ts
+++ b/src/create_helpers.ts
@@ -341,8 +341,12 @@ export function createNamespaceMember(doclet: IMemberDoclet): ts.VariableStateme
 {
     const mods = doclet.memberof ? undefined : [declareModifier];
     const flags = (doclet.kind === 'constant' || doclet.readonly) ? ts.NodeFlags.Const : undefined;
-    const literal = doclet.meta && doclet.meta.code.type === 'Literal' ? doclet.meta.code.value : undefined;
-    const initializer = (flags === ts.NodeFlags.Const && literal !== undefined) ? ts.createLiteral(literal) : undefined;
+
+    const literalValue = doclet.meta && doclet.meta.code.type === 'Literal' ? doclet.meta.code.value : undefined;
+    const defaultValue = doclet.defaultvalue !== undefined ? doclet.defaultvalue : literalValue;
+    const initializer = (flags === ts.NodeFlags.Const && defaultValue !== undefined) ? ts.createLiteral(defaultValue) : undefined;
+
+    // ignore regular type if its a constant value, because that strict value provides more type information
     const type = initializer ? undefined : resolveType(doclet.type, doclet);
 
     if (doclet.name.startsWith('exports.'))

--- a/src/create_helpers.ts
+++ b/src/create_helpers.ts
@@ -340,6 +340,7 @@ export function createInterfaceMember(doclet: IMemberDoclet): ts.PropertySignatu
 export function createNamespaceMember(doclet: IMemberDoclet): ts.VariableStatement
 {
     const mods = doclet.memberof ? undefined : [declareModifier];
+    const flags = doclet.kind === 'constant' ? ts.NodeFlags.Const : undefined;
     const type = resolveType(doclet.type, doclet);
 
     if (doclet.name.startsWith('exports.'))
@@ -347,11 +348,15 @@ export function createNamespaceMember(doclet: IMemberDoclet): ts.VariableStateme
 
     return handleComment(doclet, ts.createVariableStatement(
         mods,
-        [ts.createVariableDeclaration(
-            doclet.name,    // name
-            type,           // type
-            undefined       // initializer
-        )]
+        ts.createVariableDeclarationList([
+            ts.createVariableDeclaration(
+                doclet.name,    // name
+                type,           // type
+                undefined       // initializer
+                )
+            ],
+            flags,
+        )
     ));
 }
 

--- a/src/create_helpers.ts
+++ b/src/create_helpers.ts
@@ -342,11 +342,12 @@ export function createNamespaceMember(doclet: IMemberDoclet): ts.VariableStateme
     const mods = doclet.memberof ? undefined : [declareModifier];
     const flags = (doclet.kind === 'constant' || doclet.readonly) ? ts.NodeFlags.Const : undefined;
 
-    const literalValue = doclet.meta && doclet.meta.code.type === 'Literal' ? doclet.meta.code.value : undefined;
-    const defaultValue = doclet.defaultvalue !== undefined ? doclet.defaultvalue : literalValue;
-    const initializer = (flags === ts.NodeFlags.Const && defaultValue !== undefined) ? ts.createLiteral(defaultValue) : undefined;
+    const literalValue = doclet.defaultvalue !== undefined ? doclet.defaultvalue
+                         : doclet.meta && doclet.meta.code.type === 'Literal' ? doclet.meta.code.value
+                         : undefined;
+    const initializer = (flags === ts.NodeFlags.Const && literalValue !== undefined) ? ts.createLiteral(literalValue) : undefined;
 
-    // ignore regular type if its a constant value, because that strict value provides more type information
+    // ignore regular type if constant literal, because a literal provides more type information
     const type = initializer ? undefined : resolveType(doclet.type, doclet);
 
     if (doclet.name.startsWith('exports.'))

--- a/test/expected/namespace_all.d.ts
+++ b/test/expected/namespace_all.d.ts
@@ -66,6 +66,20 @@ declare namespace FoobarNS {
     class Circle {
         constructor(opt_options?: FoobarNS.CircleOptions);
     }
+    /**
+     * Hello World #1
+     * @member {Number}
+     */
+    var helloWorld1: number;
+    /**
+     * Hello World #2
+     * @type {Boolean}
+     */
+    var helloWorld2: boolean;
+    /**
+     * Hello World #3
+     * @constant
+     * @type {String}
+     */
+    const helloWorld3: string;
 }
-
-

--- a/test/expected/namespace_all.d.ts
+++ b/test/expected/namespace_all.d.ts
@@ -67,19 +67,46 @@ declare namespace FoobarNS {
         constructor(opt_options?: FoobarNS.CircleOptions);
     }
     /**
-     * Hello World #1
      * @member {Number}
      */
     var helloWorld1: number;
     /**
-     * Hello World #2
      * @type {Boolean}
      */
     var helloWorld2: boolean;
     /**
-     * Hello World #3
      * @constant
      * @type {String}
      */
     const helloWorld3: string;
+    /**
+     * @constant
+     * @type {Number}
+     */
+    const helloWorld4: number;
+    /**
+     * @constant
+     * @type {Boolean}
+     */
+    const helloWorld5: boolean;
+    /**
+     * @constant
+     * @type {Object}
+     */
+    const helloWorld6: any;
+    /**
+     * @constant
+     * @type {String}
+     */
+    const helloWorld7 = "test";
+    /**
+     * @constant
+     * @type {Number}
+     */
+    const helloWorld8 = 1.2345;
+    /**
+     * @constant
+     * @type {Boolean}
+     */
+    const helloWorld9 = true;
 }

--- a/test/fixtures/namespace_all.js
+++ b/test/fixtures/namespace_all.js
@@ -69,3 +69,22 @@ FoobarNS.CircleOptions.prototype.radius;
  */
 FoobarNS.Circle = function Circle(opt_options) {
 }
+
+/**
+ * Hello World #1
+ * @member {Number}
+ */
+FoobarNS.helloWorld1 = 1;
+
+/**
+ * Hello World #2
+ * @type {Boolean}
+ */
+FoobarNS.helloWorld2 = true;
+
+/**
+ * Hello World #3
+ * @constant
+ * @type {String}
+ */
+FoobarNS.helloWorld3 = "test";

--- a/test/fixtures/namespace_all.js
+++ b/test/fixtures/namespace_all.js
@@ -71,20 +71,53 @@ FoobarNS.Circle = function Circle(opt_options) {
 }
 
 /**
- * Hello World #1
  * @member {Number}
  */
 FoobarNS.helloWorld1 = 1;
 
 /**
- * Hello World #2
  * @type {Boolean}
  */
 FoobarNS.helloWorld2 = true;
 
 /**
- * Hello World #3
  * @constant
  * @type {String}
  */
-FoobarNS.helloWorld3 = "test";
+FoobarNS.helloWorld3 = foobar;
+
+/**
+ * @constant
+ * @type {Number}
+ */
+FoobarNS.helloWorld4 = foobar;
+
+/**
+ * @constant
+ * @type {Boolean}
+ */
+FoobarNS.helloWorld5 = foobar;
+
+/**
+ * @constant
+ * @type {Object}
+ */
+FoobarNS.helloWorld6 = {hello: "world", test: 7.0, foo: "bar"};
+
+/**
+ * @constant
+ * @type {String}
+ */
+FoobarNS.helloWorld7 = "test";
+
+/**
+ * @constant
+ * @type {Number}
+ */
+FoobarNS.helloWorld8 = 1.2345;
+
+/**
+ * @constant
+ * @type {Boolean}
+ */
+FoobarNS.helloWorld9 = true;


### PR DESCRIPTION
This PR adds proper support for constant declarations in a namespace. Without it, the `d.ts` output will just be a regular non-constant variable. Additionally, if the constant has a default or literal value, it will be included in the declaration (because it is more actionable type information).