### PR TITLE
support static members/methods in an interface

### DIFF
--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -200,8 +200,10 @@ export class Emitter
                 {
                     const mod = this._getOrCreateClassNamespace(parent);
 
-                    if (interfaceMerge) mod.children.push(interfaceMerge);
-                    if (namespaceMerge) mod.children.push(namespaceMerge);
+                    if (interfaceMerge)
+                        mod.children.push(interfaceMerge);
+                    if (namespaceMerge)
+                        mod.children.push(namespaceMerge);
 
                     mod.children.push(obj);
                 }
@@ -217,8 +219,10 @@ export class Emitter
 
                     if (!isParentEnum)
                     {
-                        if (interfaceMerge) parent.children.push(interfaceMerge);
-                        if (namespaceMerge) parent.children.push(namespaceMerge);
+                        if (interfaceMerge)
+                            parent.children.push(interfaceMerge);
+                        if (namespaceMerge)
+                            parent.children.push(namespaceMerge);
 
                         parent.children.push(obj);
                     }
@@ -226,8 +230,10 @@ export class Emitter
             }
             else
             {
-                if (interfaceMerge) this._treeRoots.push(interfaceMerge);
-                if (namespaceMerge) this._treeRoots.push(namespaceMerge);
+                if (interfaceMerge)
+                    this._treeRoots.push(interfaceMerge);
+                if (namespaceMerge)
+                    this._treeRoots.push(namespaceMerge);
 
                 this._treeRoots.push(obj);
             }

--- a/test/expected/interface_all.d.ts
+++ b/test/expected/interface_all.d.ts
@@ -1,3 +1,33 @@
+declare namespace Color {
+    /**
+     * @function Color.staticMethod1
+     */
+    function staticMethod1(): void;
+    /**
+     * @function
+     * @static
+     */
+    function staticMethod2(): void;
+    /**
+     * @member {Number} Color.staticMember1
+     */
+    var staticMember1: number;
+    /**
+     * @member {Boolean}
+     * @static
+     */
+    var staticMember2: boolean;
+    /**
+    * @type {String}
+    * @name Color.staticMember3
+     */
+    var staticMember3: string;
+    /**
+    * @type {Object}
+    * @static
+     */
+    var staticMember4: any;
+}
 /**
  * Interface for classes that represent a color.
  *

--- a/test/expected/interface_all.d.ts
+++ b/test/expected/interface_all.d.ts
@@ -28,12 +28,21 @@ declare namespace Color {
      */
     var staticMember4: any;
 }
+
 /**
  * Interface for classes that represent a color.
  *
  * @interface
  */
 declare interface Color {
+    /**
+     * @function
+     */
+    instanceMethod(): void;
+    /**
+     * @member {Number}
+     */
+    instanceMember: number;
     /**
      * Get the color as an array of red, green, and blue values, represented as
      * decimal numbers between 0 and 1.

--- a/test/fixtures/interface_all.js
+++ b/test/fixtures/interface_all.js
@@ -39,6 +39,15 @@ Color.staticMember3 = "foobar";
 */
 Color.staticMember4 = {};
 
+/**
+ * @function
+ */
+Color.prototype.instanceMethod = function() {};
+
+/**
+ * @member {Number}
+ */
+Color.prototype.instanceMember = 5;
 
 /**
  * Get the color as an array of red, green, and blue values, represented as
@@ -50,5 +59,3 @@ Color.staticMember4 = {};
 Color.prototype.rgb = function() {
     throw new Error('not implemented');
 };
-
-

--- a/test/fixtures/interface_all.js
+++ b/test/fixtures/interface_all.js
@@ -6,6 +6,41 @@
 function Color() {}
 
 /**
+ * @function Color.staticMethod1
+ */
+Color.staticMethod1 = function() {};
+
+/**
+ * @function
+ * @static
+ */
+Color.staticMethod2 = function() {};
+
+/**
+ * @member {Number} Color.staticMember1
+ */
+Color.staticMember1 = 1;
+
+/**
+ * @member {Boolean}
+ * @static
+ */
+Color.staticMember2 = true;
+
+/**
+* @type {String}
+* @name Color.staticMember3
+*/
+Color.staticMember3 = "foobar";
+
+/**
+* @type {Object}
+* @static
+*/
+Color.staticMember4 = {};
+
+
+/**
  * Get the color as an array of red, green, and blue values, represented as
  * decimal numbers between 0 and 1.
  *


### PR DESCRIPTION
JSDoc allows members (like functions and variables) to be static inside an interface (or mixin). Currently, this will generate invalid TypeScript. This PR fixes that by moving all static members to a namespace (which has the same name as the interface) and thus performs a namespace merge.

So the following JavaScript:
```javascript
/**
 * @interface
 */
function Color() {}

/**
 * @function Color.staticMethod1
 * @static
 */
Color.staticMethod = function() {};

/**
 * @member {Number}
 * @static
 */
Color.staticMember = 1;

/**
 * @function
 */
Color.prototype.instanceMethod = function() {};

/**
 * @member {Number}
 */
Color.prototype.instanceMember = 2;
```

Will generate the following TypeScript:
```typescript
declare namespace Color {
    /**
     * @function
     * @static
     */
    function staticMethod(): void;
    /**
     * @member {Number}
     * @static
     */
    var staticMember: number;
}

/**
 * @interface
 */
declare interface Color {
    /**
     * @function
     */
    instanceMethod(): void;
    /**
     * @member {Number}
     */
    instanceMember: number;
}
```
Which is perfectly valid TypeScript.