### PR TITLE
resolves #113 Added source location information to warnings

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -7,12 +7,19 @@ export function setVerbose(value: boolean)
     isVerbose = value;
 }
 
-export function warn(msg: string, data?: any)
+export function warn(msg: string, data?: any|TAnyDoclet)
 {
+
     if (typeof(console) === 'undefined')
         return;
 
-    console.warn(`${header} ${msg}`);
+    let prefix = header;
+    if (arguments.length > 1 && data && data.hasOwnProperty('meta')) {
+        const meta = data.meta;
+        prefix = `${prefix} ${meta.filename}:${meta.lineno}:${meta.columnno}`;
+    }
+
+    console.warn(`${prefix} ${msg}`);
 
     if (isVerbose && arguments.length > 1)
     {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -13,7 +13,8 @@ export function warn(msg: string, data?: any)
         return;
 
     let prefix = header;
-    if (arguments.length > 1 && data && data.hasOwnProperty('meta')) {
+    if (data && data.meta)
+    {
         const meta = data.meta;
         prefix = `${prefix} ${meta.filename}:${meta.lineno}:${meta.columnno}`;
     }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -9,7 +9,6 @@ export function setVerbose(value: boolean)
 
 export function warn(msg: string, data?: any)
 {
-
     if (typeof(console) === 'undefined')
         return;
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -7,7 +7,7 @@ export function setVerbose(value: boolean)
     isVerbose = value;
 }
 
-export function warn(msg: string, data?: any|TAnyDoclet)
+export function warn(msg: string, data?: any)
 {
 
     if (typeof(console) === 'undefined')


### PR DESCRIPTION
The error messages are missing source locations for ease of navigating. This PR add to every logged error: Source filename (not the path), line number, and column number:

```
[TSD-JSDoc] dataset.js:619:4 Failed to find parent of doclet 'DatasetLocal#_getItemIndexes' using memberof 'DatasetLocal', this is likely due to invalid JSDoc.
[TSD-JSDoc] dataset.js:630:4 Failed to find parent of doclet 'DatasetLocal#_readAndParseFile' using memberof 'DatasetLocal', this is likely due to invalid JSDoc.
[TSD-JSDoc] stealth.js:40:0 Failed to find parent of doclet 'module.exports' using memberof 'module', this is likely due to invalid JSDoc.
[TSD-JSDoc] autoscaled_pool.js:209:4 Unable to resolve type for AutoscaledPool#minConcurrency, none specified in JSDoc. Defaulting to `any`.
```

Please review and comment.