### PR TITLE
Resolves #111 preserve comment on enum members

### DIFF
--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -2,6 +2,7 @@ import * as ts from 'typescript';
 import { Dictionary } from './Dictionary';
 import { warn } from './logger';
 import { assertNever } from './assert_never';
+import { isClassDoclet, isNamespaceDoclet, isEnumDoclet } from './doclet_utils';
 import {
     createClass,
     createFunction,
@@ -24,26 +25,11 @@ interface IDocletTreeNode
     isNested?: boolean;
 }
 
-function isClassLike(doclet: TDoclet)
-{
-    return doclet.kind === 'class' || doclet.kind === 'interface' || doclet.kind === 'mixin';
-}
-
-function isModuleLike(doclet: TDoclet)
-{
-    return doclet.kind === 'module' || doclet.kind === 'namespace';
-}
-
-function isEnum(doclet: TDoclet)
-{
-    return (doclet.kind === 'member' || doclet.kind === 'constant') && doclet.isEnum;
-}
-
 function shouldMoveOutOfClass(doclet: TDoclet)
 {
-    return isClassLike(doclet)
-        || isModuleLike(doclet)
-        || isEnum(doclet)
+    return isClassDoclet(doclet)
+        || isNamespaceDoclet(doclet)
+        || isEnumDoclet(doclet)
         || doclet.kind === 'typedef';
 }
 
@@ -193,7 +179,7 @@ export class Emitter
                     continue;
                 }
 
-                const isParentClassLike = isClassLike(parent.doclet);
+                const isParentClassLike = isClassDoclet(parent.doclet);
 
                 // We need to move this into a module of the same name as the parent
                 if (isParentClassLike && shouldMoveOutOfClass(doclet))
@@ -209,13 +195,13 @@ export class Emitter
                 }
                 else
                 {
-                    const isObjModuleLike = isModuleLike(doclet);
-                    const isParentModuleLike = isModuleLike(parent.doclet);
+                    const isObjModuleLike = isNamespaceDoclet(doclet);
+                    const isParentModuleLike = isNamespaceDoclet(parent.doclet);
 
                     if (isObjModuleLike && isParentModuleLike)
                         obj.isNested = true;
 
-                    const isParentEnum = isEnum(parent.doclet);
+                    const isParentEnum = isEnumDoclet(parent.doclet);
 
                     if (!isParentEnum)
                     {

--- a/src/create_helpers.ts
+++ b/src/create_helpers.ts
@@ -1,5 +1,7 @@
 import * as ts from 'typescript';
 import { warn } from './logger';
+import { isClassDoclet, isEnumDoclet, isFileDoclet, isEventDoclet, isFunctionDoclet, isTypedefDoclet } from './doclet_utils';
+import { PropTree } from "./PropTree";
 import {
     createFunctionParams,
     createFunctionReturnType,
@@ -9,13 +11,12 @@ import {
     resolveTypeParameters,
     resolveOptionalFromName
 } from './type_resolve_helpers';
-import { PropTree } from "./PropTree";
 
 const declareModifier = ts.createModifier(ts.SyntaxKind.DeclareKeyword);
 const constModifier = ts.createModifier(ts.SyntaxKind.ConstKeyword);
 const readonlyModifier = ts.createModifier(ts.SyntaxKind.ReadonlyKeyword);
 
-function validateClassLikeChildren(children: ts.Node[] | undefined, validate: (n: ts.Node) => boolean, msg: string)
+function validateClassLikeChildren(children: ts.Node[] | undefined, validate: (n: ts.Node) => boolean, msg: string): void
 {
     // Validate that the children array actually contains type elements.
     // This should never trigger, but is here for safety.
@@ -33,17 +34,17 @@ function validateClassLikeChildren(children: ts.Node[] | undefined, validate: (n
     }
 }
 
-function validateClassChildren(children: ts.Node[] | undefined)
+function validateClassChildren(children: ts.Node[] | undefined): void
 {
-    return validateClassLikeChildren(children, ts.isClassElement, 'ClassElement');
+    validateClassLikeChildren(children, ts.isClassElement, 'ClassElement');
 }
 
-function validateInterfaceChildren(children: ts.Node[] | undefined)
+function validateInterfaceChildren(children: ts.Node[] | undefined): void
 {
-    return validateClassLikeChildren(children, ts.isTypeElement, 'TypeElement');
+    validateClassLikeChildren(children, ts.isTypeElement, 'TypeElement');
 }
 
-function validateModuleChildren(children?: ts.Node[])
+function validateModuleChildren(children?: ts.Node[]): void
 {
     // Validate that the children array actually contains declaration elements.
     // This should never trigger, but is here for safety.
@@ -101,23 +102,24 @@ function handlePropsComment(props: IDocletProp[], jsdocTagName: String): string
     }).filter((value) => value !== '').join('')
 }
 
-function handleReturnsComment(doclet: IDocletBase): string
+function handleReturnsComment(doclet: TDoclet): string
 {
-    if ('returns' in doclet)
+    if (doclet.kind === 'function' && doclet.returns)
     {
-        return (doclet['returns'] as IDocletReturn[]).map((ret) =>
+        return doclet.returns.map((ret) =>
         {
             if (ret.description)
-            {
                 return `\n * @returns ${formatMultilineComment(ret.description)}`;
-            }
+
             return '';
-        }).filter((value) => value !== '').join('');
+        })
+        .filter((value) => value !== '').join('');
     }
-    return ''
+
+    return '';
 }
 
-function handleExamplesComment(doclet: IDocletBase): string
+function handleExamplesComment(doclet: TDoclet): string
 {
     if (doclet.examples !== undefined)
     {
@@ -125,30 +127,39 @@ function handleExamplesComment(doclet: IDocletBase): string
         {
             return `\n * @example
  * ${formatMultilineComment(example)}`;
-        }).join('');
+        })
+        .join('');
     }
+
     return '';
 }
 
-function handleParamsComment(doclet: IDocletBase): string
+function handleParamsComment(doclet: TDoclet): string
 {
-    if ('params' in doclet)
+    if ((isClassDoclet(doclet)
+        || isFileDoclet(doclet)
+        || isEventDoclet(doclet)
+        || isFunctionDoclet(doclet)
+        || isTypedefDoclet(doclet))
+        && doclet.params)
     {
-        return handlePropsComment((doclet['params'] as IDocletProp[]), 'param');
+        return handlePropsComment(doclet.params, 'param');
     }
+
     return ''
 }
 
-function handlePropertiesComment(doclet: IDocletBase): string
+function handlePropertiesComment(doclet: TDoclet): string
 {
-    if (doclet.properties && (!('isEnum' in doclet) || (doclet['isEnum'] === false)))
+    if (!isEnumDoclet(doclet) && doclet.properties)
     {
         return handlePropsComment(doclet.properties, 'property');
     }
+
     return ''
 }
 
-function handleComment<T extends ts.Node>(doclet: IDocletBase, node: T): T
+function handleComment<T extends ts.Node>(doclet: TDoclet, node: T): T
 {
     if (doclet.comment && doclet.comment.length > 4)
     {
@@ -157,30 +168,40 @@ function handleComment<T extends ts.Node>(doclet: IDocletBase, node: T): T
         {
             description = `\n * ${formatMultilineComment(doclet.description)}`;
         }
-        else if ('classdesc' in doclet)
+        else if (isClassDoclet(doclet) && doclet.classdesc)
         {
-            description = `\n * ${formatMultilineComment((doclet['classdesc'] as string))}`;
+            description = `\n * ${formatMultilineComment(doclet.classdesc)}`;
         }
+
         const examples = handleExamplesComment(doclet);
         const properties = handlePropertiesComment(doclet);
         const params = handleParamsComment(doclet);
         const returns = handleReturnsComment(doclet);
 
-        if ('isEnum' in doclet && doclet['isEnum'] === true)
+        if (isEnumDoclet(doclet))
         {
-            if ('properties' in doclet)
+            if (!ts.isEnumDeclaration(node))
             {
-                const enumProperties = (doclet['properties'] as Array<IDocletBase>);
-                // @ts-ignore
-                const enumMembers = node['members'];
+                warn(`Node is not an enum declaration, even though the doclet is. This is likely a tsd-jsdoc bug.`);
+                return node;
+            }
+
+            if (doclet.properties)
+            {
+                const enumProperties = doclet.properties;
+                const enumMembers = node.members;
+
                 for (let index = 0; index < enumProperties.length; index++)
                 {
                     const enumProperty = enumProperties[index];
                     const enumMember = enumMembers[index];
-                    handleComment(enumProperty, enumMember);
+
+                    // TODO: Remove this type assertion.
+                    handleComment(enumProperty as IMemberDoclet, enumMember);
                 }
             }
         }
+
         if (description || examples || properties || params || returns)
         {
             let comment = `*${description}${examples}${properties}${params}${returns}

--- a/src/create_helpers.ts
+++ b/src/create_helpers.ts
@@ -166,6 +166,21 @@ function handleComment<T extends ts.Node>(doclet: IDocletBase, node: T): T
         const params = handleParamsComment(doclet);
         const returns = handleReturnsComment(doclet);
 
+        if ('isEnum' in doclet && doclet['isEnum'] === true)
+        {
+            if ('properties' in doclet)
+            {
+                const enumProperties = (doclet['properties'] as Array<IDocletBase>);
+                // @ts-ignore
+                const enumMembers = node['members'];
+                for (let index = 0; index < enumProperties.length; index++)
+                {
+                    const enumProperty = enumProperties[index];
+                    const enumMember = enumMembers[index];
+                    handleComment(enumProperty, enumMember);
+                }
+            }
+        }
         if (description || examples || properties || params || returns)
         {
             let comment = `*${description}${examples}${properties}${params}${returns}

--- a/src/create_helpers.ts
+++ b/src/create_helpers.ts
@@ -104,7 +104,7 @@ function handlePropsComment(props: IDocletProp[], jsdocTagName: String): string
 
 function handleReturnsComment(doclet: TDoclet): string
 {
-    if (doclet.kind === 'function' && doclet.returns)
+    if (isFunctionDoclet(doclet) && doclet.returns)
     {
         return doclet.returns.map((ret) =>
         {

--- a/src/doclet_utils.ts
+++ b/src/doclet_utils.ts
@@ -1,0 +1,44 @@
+export function isClassDoclet(doclet: TDoclet): doclet is IClassDoclet
+{
+    return doclet.kind === 'class' || doclet.kind === 'interface' || doclet.kind === 'mixin';
+}
+
+export function isFileDoclet(doclet: TDoclet): doclet is IFileDoclet
+{
+    return doclet.kind === 'file';
+}
+
+export function isEventDoclet(doclet: TDoclet): doclet is IEventDoclet
+{
+    return doclet.kind === 'event';
+}
+
+export function isFunctionDoclet(doclet: TDoclet): doclet is IFunctionDoclet
+{
+    return doclet.kind === 'function' || doclet.kind === 'callback';
+}
+
+export function isMemberDoclet(doclet: TDoclet): doclet is IMemberDoclet
+{
+    return doclet.kind === 'member' || doclet.kind === 'constant';
+}
+
+export function isNamespaceDoclet(doclet: TDoclet): doclet is INamespaceDoclet
+{
+    return doclet.kind === 'module' || doclet.kind === 'namespace';
+}
+
+export function isTypedefDoclet(doclet: TDoclet): doclet is ITypedefDoclet
+{
+    return doclet.kind === 'typedef';
+}
+
+export function isPackageDoclet(doclet: TAnyDoclet): doclet is IPackageDoclet
+{
+    return doclet.kind === 'package';
+}
+
+export function isEnumDoclet(doclet: TDoclet): doclet is IMemberDoclet
+{
+    return isMemberDoclet(doclet) && doclet.isEnum;
+}

--- a/src/typings/jsdoc.d.ts
+++ b/src/typings/jsdoc.d.ts
@@ -152,8 +152,8 @@ declare interface IPackageDoclet {
 
 declare type TDoclet = (
     IClassDoclet
-    | IEventDoclet
     | IFileDoclet
+    | IEventDoclet
     | IFunctionDoclet
     | IMemberDoclet
     | INamespaceDoclet

--- a/test/expected/enum_all.d.ts
+++ b/test/expected/enum_all.d.ts
@@ -2,9 +2,14 @@
  * Enum for tri-state values.
  */
 declare enum triState {
+    /**
+     * The true value
+     */
     TRUE = 1,
+    /**
+     * The false value
+     */
     FALSE = -1,
     MAYBE = true
 }
-
 


### PR DESCRIPTION
Cleanup some TS checks from #115 and refactor doclet type getters into a separate file.

This removes all the `'string' in obj` checks and usages of `obj['string']`.

Fixes #111.