### PR TITLE
Improve documentation, building, and debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "node",
+			"request": "launch",
+			"preLaunchTask": "npm: build",
+			"name": "Debug All",
+			"program": "${workspaceFolder}/node_modules/jsdoc/jsdoc.js",
+			"args": [
+				"${workspaceFolder}/test/fixtures",
+				"--destination",
+				"${workspaceFolder}/test/_temp",
+				"--configure",
+				"${workspaceFolder}/jsdoc-conf.json",
+				"--debug"
+			],
+			"console": "integratedTerminal",
+			"internalConsoleOptions": "neverOpen"
+		}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ Or add this to your JSON configuration:
 }
 ```
 
+If you want to use jsdoc/closure tag `@template`, you also need to specify this module as a plugin, like so:
+
+```json
+{
+    "plugins": [ "./node_modules/tsd-jsdoc/dist/plugin" ],
+    "opts": {
+        "template": "./node_modules/tsd-jsdoc/dist"
+    }
+}
+```
+
 ## Validation
 
 This library provides very little validation beyond what JSDoc provides. Meaning if you

--- a/jsdoc-conf.json
+++ b/jsdoc-conf.json
@@ -1,0 +1,6 @@
+{
+    "plugins": [ "dist/plugin" ],
+    "opts": {
+        "template": "dist"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "tsc -p tsconfig.json",
     "watch": "tsc -w -p tsconfig.json",
     "prepare": "npm run build",
-    "test": "mocha --ui tdd -r ts-node/register test/specs/**.ts"
+    "test": "npm run build && mocha --ui tdd -r ts-node/register test/specs/**.ts"
   },
   "files": [
     "dist/*",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,4 @@
-exports.defineTags = function(dictionary) {
+export function defineTags(dictionary: ITagDictionary) {
     dictionary.defineTag("template", {
         onTagged: function(doclet, tag) {
             doclet.tags = doclet.tags || [];

--- a/src/typings/jsdoc.d.ts
+++ b/src/typings/jsdoc.d.ts
@@ -161,3 +161,32 @@ declare type TDoclet = (
 );
 
 declare type TAnyDoclet = TDoclet | IPackageDoclet;
+
+declare interface ITagDictionary {
+    defineTag(title: string, opts: ITagDefinitionOptions): ITagDefinition;
+    defineSynonym(title: string, synonym: string): void;
+    getNamespaces(): string[];
+    lookUp(title: string): ITagDefinition | boolean;
+    isNamespace(kind: string): boolean;
+    normalise(title: string): string;
+    normalize(title: string): string;
+}
+
+declare interface ITagDefinitionOptions {
+    isNamespace?: boolean;
+    mustNotHaveValue?: boolean;
+    mustHaveValue?: boolean;
+    canHaveType?: boolean;
+    canHaveName?: boolean;
+    synonyms?: string[];
+    keepsWhitespace?: boolean;
+    removesIndent?: boolean;
+
+    onTagText?: (text: string) => string;
+    onTagged: (doclet: TDoclet, tag: IDocletTag) => void;
+}
+
+declare interface ITagDefinition extends ITagDefinitionOptions {
+    title: string;
+    synonym(synonymName: string): ITagDefinition;
+}

--- a/test/lib/conf.json
+++ b/test/lib/conf.json
@@ -1,3 +1,0 @@
-{
-    "plugins": ["plugin"]
-}

--- a/test/lib/index.ts
+++ b/test/lib/index.ts
@@ -9,9 +9,7 @@ import { expect } from 'chai';
 const DEST_DIR = path.resolve(path.join(__dirname, '../_temp'));
 const DATA_DIR = path.resolve(path.join(__dirname, '../fixtures'));
 const EXPECT_DIR = path.resolve(path.join(__dirname, '../expected'));
-const README_PATH = path.resolve(path.join(__dirname, '../../README.md'));
-const TEMPLATE_PATH = path.resolve(path.join(__dirname, '../../dist'));
-const CONFIG_PATH = path.resolve(path.join(__dirname, "./conf.json"));
+const CONFIG_PATH = path.resolve(path.join(__dirname, '../../jsdoc-conf.json'));
 
 before(() => {
     // create the temp dir to store types in
@@ -25,8 +23,6 @@ export function compileJsdoc(sourcePath: string) {
         files: sourcePath,
         cache: false,
         destination: DEST_DIR,
-        readme: README_PATH,
-        template: TEMPLATE_PATH,
         configure: CONFIG_PATH
     } as any);
 }


### PR DESCRIPTION
PR changes:
- Move `test/lib/plugin.js` to `src/plugin.ts`
- Move `test/lib/conf.json` to `jsdoc-conf.json`
- Add necessary jsdoc API declarations for `plugin.ts`
- Add documentation for how to enable plugin's `@template` support
- Make sure source is rebuilt before running tests
- Add launch settings for vscode to allow debugging