### PR TITLE
Enable console logging for tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -350,6 +350,14 @@
         "object-to-spawn-args": "^1.1.1",
         "temp-path": "^1.0.0",
         "walk-back": "^3.0.1"
+      },
+      "dependencies": {
+        "object-to-spawn-args": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-1.1.1.tgz",
+          "integrity": "sha1-d9qIJ/Bz0BHJ4bFz+JV4FHAkZ4U=",
+          "dev": true
+        }
       }
     },
     "klaw": {
@@ -480,9 +488,9 @@
       "dev": true
     },
     "object-to-spawn-args": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-1.1.1.tgz",
-      "integrity": "sha1-d9qIJ/Bz0BHJ4bFz+JV4FHAkZ4U=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-2.0.0.tgz",
+      "integrity": "sha512-ZMT4owlXg3JGegecLlAgAA/6BsdKHn63R3ayXcAa3zFkF7oUBHcSb0oxszeutYe0FO2c1lT5pwCuidLkC4Gx3g==",
       "dev": true
     },
     "once": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "jsdoc": "^3.6.3",
     "jsdoc-api": "^5.0.3",
     "mocha": "^5.2.0",
+    "object-to-spawn-args": "^2.0.0",
     "ts-node": "^7.0.1"
   },
   "peerDependencies": {

--- a/test/expected/namespace_all.d.ts
+++ b/test/expected/namespace_all.d.ts
@@ -9,7 +9,7 @@ declare namespace FoobarNS {
          * @param [opt_this = 10] - An object.
          * @param [opt_2 = 10] - An object.
          */
-        f<S>(f: FoobarNS.Foo.FCallback, opt_this?: any, opt_2?: number[] | {
+        f<S>(f: FoobarNS.Foo.FCallback, opt_this?: number, opt_2?: number[] | {
             [key: number]: string[];
         }): void;
     }

--- a/test/fixtures/namespace_all.js
+++ b/test/fixtures/namespace_all.js
@@ -25,7 +25,7 @@ FoobarNS.Foo = function Foo() {
 /**
  * A generic method.
  * @param {FoobarNS.Foo.FCallback} f A function.
- * @param [opt_this=10] An object.
+ * @param {number} [opt_this=10] An object.
  * @param {number[]|object<number, string[]>} [opt_2=10] An object.
  * @template S
  */

--- a/test/lib/index.ts
+++ b/test/lib/index.ts
@@ -1,10 +1,7 @@
-// tslint:disable-next-line
-/// <reference path="../typings/jsdoc-api.d.ts" />
-
 import * as fs from 'fs';
 import * as path from 'path';
-import * as jsdocApi from 'jsdoc-api';
 import { expect } from 'chai';
+import { renderSync } from './render';
 
 const DEST_DIR = path.resolve(path.join(__dirname, '../_temp'));
 const DATA_DIR = path.resolve(path.join(__dirname, '../fixtures'));
@@ -19,12 +16,12 @@ before(() => {
 });
 
 export function compileJsdoc(sourcePath: string) {
-    jsdocApi.renderSync({
+    renderSync({
         files: sourcePath,
         cache: false,
         destination: DEST_DIR,
         configure: CONFIG_PATH
-    } as any);
+    });
 }
 
 export function expectJsDoc(fileName: string) {

--- a/test/lib/jsdoc-api.d.ts
+++ b/test/lib/jsdoc-api.d.ts
@@ -1,0 +1,88 @@
+import Cache from 'cache-point';
+import FileSet from 'file-set';
+
+export namespace JsdocApi {
+    function explain(options: JsdocOptions): Promise<any[]>;
+    function explainSync(options: JsdocOptions): any[];
+    function renderSync(options: JsdocOptions): void;
+}
+
+export interface JsdocOptions {
+    /** One or more filenames to process. Either this or `source` must be supplied. */
+    files?: string|string[];
+    /** A string containing source code to process. Either this or `source` must be supplied. */
+    source?: string;
+    /** Set to `true` to cache the output - future invocations with the same input will return immediately. */
+    cache?: boolean;
+    /** Only display symbols with the given access: "public", "protected", "private" or "undefined", or "all" for all access levels. Default: all except "private". */
+    access?: string;
+    /** The path to the configuration file. Default: path/to/jsdoc/conf.json. */
+    configure?: string;
+    /** The path to the output folder. Use "console" to dump data to the console. Default: ./out/. */
+    destination?: string;
+    /** Assume this encoding when reading all source files. Default: utf8. */
+    encoding?: string;
+    /** Display symbols marked with the `@private` tag. Equivalent to "--access all". Default: false. */
+    private?: boolean;
+    /** The path to the project's package file. Default: path/to/sourcefiles/package.json */
+    package?: string;
+    /** Treat errors as fatal errors, and treat warnings as errors. Default: false. */
+    pedantic?: boolean;
+    /** A query string to parse and store in jsdoc.env.opts.query. Example: foo=bar&baz=true. */
+    query?: string;
+    /** Recurse into subdirectories when scanning for source files and tutorials. */
+    recurse?: boolean;
+    /** The path to the project's README file. Default: path/to/sourcefiles/README.md. */
+    readme?: string;
+    /** The path to the template to use. Default: path/to/jsdoc/templates/default. */
+    template?: string;
+    /** Directory in which JSDoc should search for tutorials. */
+    tutorials?: string;
+}
+
+export class TempFile {
+    path: string;
+}
+
+/**
+ * Command base class. The command `receiver` being the `child_process` module.
+ */
+export abstract class JsdocCommand {
+    cache?: Cache;
+    tempFile: TempFile | null;
+    options: JsdocOptions;
+    jsdocOptions: JsdocOptions;
+    jsdocPath: string;
+    inputFileSet?: FileSet;
+    output?: any;
+
+    constructor (options: JsdocOptions, cache?: Cache);
+
+    abstract getOutput(): any;
+
+    /**
+     * Template method returning the jsdoc output. Invoke later (for example via a command-queuing system) or immediately as required.
+     *
+     * 1. preExecute
+     * 2. validate
+     * 3. getOutput
+     * 4. postExecute
+     *
+     */
+    execute(): any;
+
+    /**
+     * Perform pre-execution processing here, e.g. expand input glob patterns.
+     */
+    preExecute(): void;
+
+    /**
+     * Return an Error instance if execution should not proceed.
+     */
+    validate(): null | Error;
+
+    /**
+     * perform post-execution cleanup
+     */
+    postExecute(): void;
+}

--- a/test/lib/jsdoc-api.js
+++ b/test/lib/jsdoc-api.js
@@ -1,0 +1,3 @@
+exports.JsdocApi = require('jsdoc-api');
+exports.JsdocCommand = require('jsdoc-api/lib/jsdoc-command');
+exports.TempFile = require('jsdoc-api/lib/temp-file');

--- a/test/lib/render.ts
+++ b/test/lib/render.ts
@@ -1,0 +1,28 @@
+import { JsdocCommand, JsdocOptions } from './jsdoc-api';
+import { spawnSync } from 'child_process';
+
+const toSpawnArgs = require('object-to-spawn-args') as
+    (object: object, options?: { quote?: boolean; optionEqualsValue?: boolean }) => string[];
+
+class RenderSync extends JsdocCommand {
+    getOutput (err?: Error) {
+        if (err) throw err;
+
+        const jsdocArgs = toSpawnArgs(this.jsdocOptions)
+            .concat(this.options.source ? this.tempFile!.path : this.options.files!);
+
+        jsdocArgs.unshift(this.jsdocPath);
+
+        spawnSync('node', jsdocArgs, {
+            cwd: process.cwd(),
+            env: process.env,
+            stdio: 'inherit',
+            encoding: 'utf-8'
+        });
+    }
+}
+
+export function renderSync(options: JsdocOptions) {
+    const command = new RenderSync(options);
+    return command.execute();
+}

--- a/test/typings/jsdoc-api.d.ts
+++ b/test/typings/jsdoc-api.d.ts
@@ -1,5 +1,0 @@
-declare module 'jsdoc-api' {
-    export function explain(options: any): Promise<any[]>;
-    export function explainSync(options: any): any[];
-    export function renderSync(options: any): void;
-}


### PR DESCRIPTION
Currently, all logging in the library is silently discarded when running the tests. Which makes detecting issues and debugging unnecessarily a lot harder. The PR fixes this by making the following changes:

1. When tests spawn a jsdoc child process (via `jsdoc-api`), configure spawn so that stdio is inherited.
2. Because `jsdoc-api` doesn't provide a way to configure the spawn in the main API, use lower-level APIs. This is what the new file `jsdoc-api.js` does (and `jsdoc-api.d.ts` provides typings for).
3. Remove the old `jsdoc-api.d.ts`, which is no longer needed.

As a bonus, I also fixed the following warning that otherwise wouldn't show up in `Namespace Checks`:
```
[TSD-JSDoc] Unable to resolve type for an unnamed item, this is likely due to invalid JSDoc.
Often this is caused by invalid JSDoc on a parameter. Defaulting to `any`.
```