### PR TITLE
Filter out inherited non-overridden members

### DIFF
--- a/src/publish.ts
+++ b/src/publish.ts
@@ -13,8 +13,8 @@ export function publish(data: TDocletDb, opts: ITemplateConfig)
     // remove undocumented stuff.
     data({ undocumented: true }).remove();
 
-    // get the doc list
-    const docs = data().get();
+    // get the doc list and filter out inherited non-overridden members
+    const docs = data().get().filter(d => !d.inherited || d.overrides);
 
     setVerbose(!!opts.verbose);
 

--- a/src/typings/jsdoc.d.ts
+++ b/src/typings/jsdoc.d.ts
@@ -88,6 +88,8 @@ declare interface IDocletBase {
     inherits?: string;
     inherited?: boolean;
     optional?: boolean;
+    override?: boolean;
+    overrides?: string;
 }
 
 /**

--- a/test/expected/class_all.d.ts
+++ b/test/expected/class_all.d.ts
@@ -8,6 +8,16 @@ declare class Stuff {
     doStuff(): void;
 }
 
+declare class BaseClass {
+    baseFunc(): void;
+    baseFuncOverridden(): void;
+}
+
+declare class DerivedClass extends BaseClass {
+    derivedFunc(): void;
+    baseFuncOverridden(): void;
+}
+
 declare class Things {
     doThings(): void;
     foobar1?(): void;

--- a/test/fixtures/class_all.js
+++ b/test/fixtures/class_all.js
@@ -30,6 +30,34 @@ class Stuff {
 /**
  *
  */
+class BaseClass {
+    /**
+     *
+     */
+    baseFunc() {}
+    /**
+     *
+     */
+    baseFuncOverridden() {}
+}
+
+/**
+ * @extends BaseClass
+ */
+class DerivedClass extends BaseClass {
+    /**
+     *
+     */
+    derivedFunc() {}
+    /**
+     *
+     */
+    baseFuncOverridden() {}
+}
+
+/**
+ *
+ */
 class Things {
     /**
      *


### PR DESCRIPTION
Fixes #125 

PR changes:
- Add test for inherited members (that fail without fix)
- Filter out inherited non-overridden members and fix failing test
