### PR TITLE
Add support for ClosureCompiler syntax "typeof T"

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Or add this to your JSON configuration:
 }
 ```
 
-If you want to use jsdoc/closure tag `@template`, you also need to specify this module as a plugin, like so:
+If you want to use [supported ClosureCompiler features](#supported-closurecompiler-features), you also need to specify this module as a pluginin your JSON configuration, like so:
 
 ```json
 {
@@ -101,16 +101,16 @@ the code are ignored. These are:
 
 All other JSDoc tags should work fine.
 
-## Supported ClosureCompiler Tags
+## Supported ClosureCompiler features
 
 ClosureCompiler has a couple tags beyond the built-in JSDoc tags that can improve your TypeScript output. Here is a complete
-list of the tags from CC that are supported in this template:
+list of the features from CC that are supported in this template:
 
-- [`@template`](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#template-t) - For generics
+- [`@template T`](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#template-t) - For generics
+- [`typeof T`](https://github.com/google/closure-compiler/wiki/Types-in-the-Closure-Type-System#the-javascript-type-language) - For typeof operator
 
-## Extended support for TS features
+## Supported non-standard features
 
-JSDoc doesn't have a way to express all the features of typescript so we treat some syntax as special case to
-create better Typescript.
+Vanilla JSDoc doesn't have a way to express all the features of TypeScript so we also support these non-standardized conventions:
 
 - `Class<T>` - If we encounter a type that is `Class<T>` we will treat it as `typeof T`. See [jsdoc3/jsdoc#1349](https://github.com/jsdoc3/jsdoc/issues/1349)

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -6,3 +6,17 @@ export function defineTags(dictionary: ITagDictionary) {
         }
     });
 };
+
+const regexTypeOf = /typeof\s+([^\|\}]+)/g
+
+export var handlers = {
+    jsdocCommentFound: function(event: { filename?: string; comment?: string; lineno?: number; }) {
+        let oldResult = "";
+        let newResult = event.comment || "";
+        while (newResult !== oldResult) {
+            oldResult = newResult;
+            newResult = newResult.replace(regexTypeOf, (typeExpression, className) => "Class<" + className + ">");
+        }
+        event.comment = newResult;
+    }
+};

--- a/test/expected/typeof_all.d.ts
+++ b/test/expected/typeof_all.d.ts
@@ -1,0 +1,23 @@
+declare class Foobar1 {
+    x: typeof MyClass;
+    y: typeof MyClass;
+    z: string | typeof MyClass;
+    u: typeof MyClass | string;
+    v: (typeof MyClass)[];
+    w: typeof Array;
+    q: typeof Array;
+    r: typeof Class;
+    s: typeof Array;
+}
+
+declare class Foobar2 {
+    x: typeof MyClass;
+    y: typeof MyClass;
+    z: string | typeof MyClass;
+    u: typeof MyClass | string;
+    v: (typeof MyClass)[];
+    w: typeof Array;
+    q: typeof Array;
+    r: typeof Class;
+    s: typeof Array;
+}

--- a/test/fixtures/typeof_all.js
+++ b/test/fixtures/typeof_all.js
@@ -1,0 +1,25 @@
+/**
+ * @property {Class<MyClass>} x
+ * @property {Class.< MyClass >} y
+ * @property {string|Class<MyClass>} z
+ * @property {Class<MyClass>|string} u
+ * @property {Array<Class<MyClass>>} v
+ * @property {Class<Array<MyClass>>} w
+ * @property {Class<MyClass[]>} q
+ * @property {Class<Class<MyClass>>} r
+ * @property {Class<Array<Class<MyClass>>>} s
+ */
+class Foobar1 {}
+
+/**
+ * @property {typeof MyClass} x
+ * @property {typeof  MyClass } y
+ * @property {string|typeof MyClass} z
+ * @property {typeof MyClass|string} u
+ * @property {Array<typeof MyClass>} v
+ * @property {typeof Array<MyClass>} w
+ * @property {typeof MyClass[]} q
+ * @property {typeof typeof MyClass} r
+ * @property {typeof Array<typeof MyClass>} s
+ */
+class Foobar2 {}

--- a/test/specs/typeof.ts
+++ b/test/specs/typeof.ts
@@ -1,0 +1,7 @@
+import { expectJsDoc } from '../lib';
+
+suite('Typeof Checks', () => {
+    test('All', () => {
+        expectJsDoc('typeof_all');
+    });
+});


### PR DESCRIPTION
Fixes #129

PR changes:
- Add support for converting `typeof T` ([as supported by CC](https://github.com/google/closure-compiler/wiki/Types-in-the-Closure-Type-System#the-javascript-type-language) and [eslint for jsdoc](https://github.com/gajus/eslint-plugin-jsdoc)) into `Class<T>`.
- Add the same tests for both `Class<T>` and `typeof T` to make sure results are equivalent.
- Update readme to reflect support for `typeof T`.
