### PR TITLE
added strict documentation flag

### DIFF
--- a/src/publish.ts
+++ b/src/publish.ts
@@ -32,7 +32,7 @@ export function publish(data: TDocletDb, opts: ITemplateConfig)
                 if (this.undocumented)
                 {
                     // Some doclets are marked 'undocumented', but actually have a 'comment' set.
-                    if ((! this.comment) || (this.comment === ''))
+                    if (opts.strictDocumentation || (! this.comment) || (this.comment === ''))
                     {
                         debug(`publish(): ${docletDebugInfo(this)} removed`);
                         return true;

--- a/src/typings/dts-jsdoc.d.ts
+++ b/src/typings/dts-jsdoc.d.ts
@@ -17,4 +17,5 @@ declare interface ITemplateConfig {
      * In order not to break backward compatibility, the 'documented' generation strategy remains the default.
      */
     generationStrategy?: ("documented" | "exported");
+    strictDocumentation?: boolean;
 }


### PR DESCRIPTION
### The Issue
I have been using a set of plugins to specificly keep doclets _out_ of my typings by setting them `undocumented`. The change in d75937645ed7eb7f162652594cd27913e7bcba95 broke this behavior. 
### The Fix
To reinstate, I have added a _strictDocumentation_ flag to re-enable the exclusion of privates and internals or what have you by setting them _undocumented_ even if they have a comment.